### PR TITLE
Draft: Add test for pushing srcd.git to srcd

### DIFF
--- a/tests/05-srcd_repo_commitwise_pushes.t
+++ b/tests/05-srcd_repo_commitwise_pushes.t
@@ -1,0 +1,42 @@
+description <<'EOF'
+Test will push the srcd repo itself to srcd, commit by commit
+and see how well it handles a simple real world git repository.
+In case of failures, we know the commit causing the problem.
+EOF
+
+fixture default
+
+start
+
+git clone "$BASE_URL/empty.git" push || die "failed to clone empty.git"
+git clone "$BASE_URL/empty.git" fetch || die "failed to clone empty.git copy"
+git -C push remote add real $SRCDIR
+git -C push fetch real || die "could not fetch srcd repo"
+
+alias commits="git -C push log --reverse --format=%h real/master"
+count=$(commits | wc -l)
+
+plan $(($count * 3))
+
+set -x
+for commit in $(commits); do
+	git -C push show $commit >&2
+	set +x
+
+	exit 1
+	output=$(git -C push push origin $commit:refs/heads/master)
+	r=$?
+	is $r 0 "pushing srcd repo commit $commit, exit status"
+	[ $r -eq 0 ] || die "$output"
+
+	output=$(git -C fetch fetch 2>&1)
+	r=$?
+	is $r 0 "fetching after push, exit status"
+	[ $r -eq 0 ] || die "$output"
+
+	is "$(git -C log --format=%h -1 origin/master)" \
+   		"$commit" \
+   		"expected commit of origin/master after fetch"
+done
+
+:

--- a/tests/05-srcd_repo_one_big_push.t
+++ b/tests/05-srcd_repo_one_big_push.t
@@ -1,0 +1,30 @@
+plan 3
+
+description <<'EOF'
+Test will push the srcd repo itself to srcd, and see how well it
+handles a simple real world git repository.
+EOF
+
+fixture default
+
+start
+
+git clone "$BASE_URL/empty.git" repo || die "failed to clone empty.git"
+git -C repo remote add real $SRCDIR
+git -C repo fetch real || die "could not fetch srcd repo"
+
+target="$(git -C repo rev-parse real/master)"
+
+git -C repo push origin real/master:refs/heads/master
+is $? 0 "pushing srcd repo to empty.git, exit status"
+
+output=$(git clone "$BASE_URL/empty.git" repo-copy 2>&1)
+r=$?
+is $r 0 "cloning empty.git after pushing changes, exit status"
+[ $r -eq 0 ] || die "$output"
+
+is "$(git -C repo-copy rev-parse HEAD)" \
+   "$target" \
+   "new clone of empty.git has updated rev"
+
+:


### PR DESCRIPTION
Currently fails to push:

    **Error** {badmatch,{error,bad_zlib}}To ssh://127.199.23.92:22222/empty.git
    error: failed to push some refs to 'ssh://127.199.23.92:22222/empty.git'
    Got:      <<<1>>>
    Expected: <<<0>>>
    not ok 1 - pushing srcd repo to empty.git, exit status